### PR TITLE
status images

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -25,6 +25,14 @@ import (
 // +kubebuilder:validation:Enum=v5.2.1.1;v5.2.2.0;v5.2.2.1;v5.2.3.0.rc1
 type CNSAVersions string
 
+type ExternalImagePullStatus int
+
+const (
+	CheckNotRun ExternalImagePullStatus = iota
+	CheckSuccess
+	CheckFailed
+)
+
 // FusionAccessSpec defines the desired state of FusionAccess
 type FusionAccessSpec struct {
 	// MachineConfig labeling for the installation of kernel-devel package
@@ -80,6 +88,10 @@ type FusionAccessStatus struct {
 	// observedGeneration is the last generation change the operator has dealt with
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Show the status of pulling an external test image
+	ExternalImagePullStatus ExternalImagePullStatus `json:"externalImagePullStatus,omitempty"`
+	// Show the error in case of failure of pulling external image
+	ExternalImagePullError string `json:"externalImagePullError,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,11 +147,7 @@ func main() {
 		setupLog.Error(err, "unable to create LocalVolumeDiscovery controller")
 		os.Exit(1)
 	}
-
-	if err = (&controller.FusionAccessReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	if err = (controller.NewFusionAccessReconciler(mgr.GetClient(), mgr.GetScheme())).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FusionAccess")
 		os.Exit(1)
 	}

--- a/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
+++ b/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
@@ -127,6 +127,13 @@ spec:
                   - type
                   type: object
                 type: array
+              externalImagePullError:
+                description: Show the error in case of failure of pulling external
+                  image
+                type: string
+              externalImagePullStatus:
+                description: Show the status of pulling an external test image
+                type: integer
               observedGeneration:
                 description: observedGeneration is the last generation change the
                   operator has dealt with

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/api/v1alpha1"
-	fusionv1alpha "github.com/openshift-storage-scale/openshift-fusion-access-operator/api/v1alpha1"
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/console"
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/localvolumediscovery"
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/machineconfig"
@@ -56,7 +55,10 @@ type FusionAccessReconciler struct {
 	CanPullImage CanPullImageFunc
 }
 
-func NewFusionAccessReconciler(client client.Client, scheme *runtime.Scheme) *FusionAccessReconciler {
+func NewFusionAccessReconciler(
+	client client.Client,
+	scheme *runtime.Scheme,
+) *FusionAccessReconciler {
 	return &FusionAccessReconciler{
 		Client:       client,
 		Scheme:       scheme,
@@ -263,7 +265,7 @@ func (r *FusionAccessReconciler) Reconcile(
 	_ = log.FromContext(ctx)
 
 	// TODO(user): your logic here
-	fusionaccess := &fusionv1alpha.FusionAccess{}
+	fusionaccess := &v1alpha1.FusionAccess{}
 	err := r.Get(ctx, req.NamespacedName, fusionaccess)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
@@ -462,7 +464,7 @@ func (r *FusionAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&fusionv1alpha.FusionAccess{}).
+		For(&v1alpha1.FusionAccess{}).
 		Complete(r)
 }
 

--- a/internal/controller/fusionaccess_controller_test.go
+++ b/internal/controller/fusionaccess_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,11 +27,14 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	kubeclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -49,11 +53,13 @@ var _ = Describe("FusionAccess Controller", func() {
 		namespace         = newNamespace("openshift-fusion-access-operator")
 		version           = newOCPVersion(oscinitVersion)
 		clusterConsole    = &operatorv1.Console{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+		testTimeout       = 5 * time.Second
 	)
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
@@ -107,15 +113,54 @@ var _ = Describe("FusionAccess Controller", func() {
 				Client:     k8sClient,
 				Scheme:     k8sClient.Scheme(),
 				fullClient: kubeclient.NewSimpleClientset(),
-				// dynamicClient: k8sClient,
+				CanPullImage: func(ctx context.Context, client kubernetes.Interface, ns, image string) (bool, error) {
+					return true, nil
+				},
 			}
 
 			_, err := FusionAccessReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
+			Expect(err).ToNot(HaveOccurred())
+			updated := &fusionv1alpha.FusionAccess{}
+			err = k8sClient.Get(ctx, typeNamespacedName, updated)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(err).To(Not(HaveOccurred()))
-
+			Expect(updated.Status.ExternalImagePullError).To(BeEmpty())
+			Expect(updated.Status.ExternalImagePullStatus).To(Equal(fusionv1alpha.CheckSuccess))
 		})
+	})
+})
+
+var _ = Describe("FusionAccessReconciler Setup", func() {
+	var (
+		k8sMgr     manager.Manager
+		reconciler *FusionAccessReconciler
+		scheme     = createFakeScheme()
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		var err error
+
+		scheme = createFakeScheme()
+		_ = clientgoscheme.AddToScheme(scheme)
+		_ = fusionv1alpha.AddToScheme(scheme)
+
+		k8sMgr, err = manager.New(cfg, manager.Options{
+			Scheme: scheme,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should initialize the reconciler without errors", func() {
+		reconciler = &FusionAccessReconciler{}
+
+		err := reconciler.SetupWithManager(k8sMgr)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(reconciler.config).ToNot(BeNil())
+		Expect(reconciler.dynamicClient).ToNot(BeNil())
+		Expect(reconciler.fullClient).ToNot(BeNil())
 	})
 })
 
@@ -134,3 +179,6 @@ func newOCPVersion(version string) *configv1.ClusterVersion {
 		},
 	}
 }
+
+var _ = Describe("FusionAccessReconciler Setup", func() {
+})

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -143,6 +143,12 @@ func GetDeploymentNamespace() (string, error) {
 	return ns, nil
 }
 
+// GetExternalTestImage returns the image to be used for testing external image pull.
+// FIXME(bandini): For now this is hardcoded, we should make sure this is
+func GetExternalTestImage() string {
+	return "quay.io/openshift-storage-scale/ibm-spectrum-scale-logs:5.2.3.0.rc1"
+}
+
 // CreateImageCheckPod creates a pod with the specified image and returns its name.
 func CreateImageCheckPod(ctx context.Context, client kubernetes.Interface, namespace, image string) (string, error) {
 	existingPod, err := client.CoreV1().Pods(namespace).Get(ctx, CheckPodName, metav1.GetOptions{})

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -147,9 +147,9 @@ func GetDeploymentNamespace() (string, error) {
 }
 
 type ConfigMap struct {
-	Kind     string                 `yaml:"kind"`
-	Metadata map[string]interface{} `yaml:"metadata"`
-	Data     map[string]string      `yaml:"data"`
+	Kind     string            `yaml:"kind"`
+	Metadata map[string]any    `yaml:"metadata"`
+	Data     map[string]string `yaml:"data"`
 }
 
 type ControllerManagerConfig struct {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -167,7 +167,7 @@ func CreateImageCheckPod(ctx context.Context, client kubernetes.Interface, names
 				{
 					Name:    CheckPodContainerName,
 					Image:   image,
-					Command: []string{"exit", "0"},
+					Command: []string{"/bin/sh", "-c", "exit", "0"},
 				},
 			},
 		},


### PR DESCRIPTION
- **Add functions to check if we can pull an image**
- **Add the pull image test to the reconcile loop**
- **Fix command**
- **Move a test to ginkgo for consistency**
- **Actually fetch a test image from the external manifests**
- **Add tests and be able to mock CanPullImage**
- **Fix linting issues**
- **Make sure we use the right timeout in tests**

## Summary by Sourcery

Add image pull status checking functionality to the FusionAccess operator

New Features:
- Implement image pull status checking for external test images in the reconciliation loop
- Add ability to extract test images from ConfigMap in install manifests

Bug Fixes:
- Fix potential issues with image pull status detection
- Improve error handling in image pull checking

Enhancements:
- Refactor utility functions to support image pull checking
- Improve test coverage for image pull and YAML parsing functions
- Add new status fields to track external image pull status

Tests:
- Add comprehensive test cases for image pull status checking
- Implement tests for YAML parsing and image extraction
- Add test coverage for different image pull scenarios